### PR TITLE
Implement GLOBAL shared database

### DIFF
--- a/engine/sql_source.go
+++ b/engine/sql_source.go
@@ -62,11 +62,11 @@ func (sq *SQLSource) Open(s Stream, l Logger, st Stopper) {
 		}
 	}
 	r, err := sq.db.Query(sq.Query, sq.QueryParameters...)
-	defer r.Close()
 	if err != nil {
 		sq.fatalerr(err, s, l)
 		return
 	}
+	defer r.Close()
 	cols, err := r.Columns()
 	if err != nil {
 		sq.fatalerr(err, s, l)


### PR DESCRIPTION
Adds the ability to write or read state from GLOBAL, an in-memory sqlite3 database. Initialization is done within GLOBAL blocks and thereafter the database can be used with queries as usual, e.g. 

```
QUERY 'A' FROM GLOBAL (
  select * from input
) INTO GLOBAL WITH (Table = 'output')
```