### PR TITLE
Allow the Reduce on Max aggregation to handle timestamps

### DIFF
--- a/transforms/common.go
+++ b/transforms/common.go
@@ -1,0 +1,31 @@
+package transforms
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	DefaultDatabaseDateFormat   = "YYYY-MM-DDTHH:MM:SSZ"
+	defaultDatabaseGoDateFormat = "2006-01-02T15:04:05Z"
+)
+
+func parseTime(s string) (*time.Time, string, error) {
+	var (
+		t   time.Time
+		err error
+	)
+	t, err = time.Parse(time.RFC3339, s)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339Nano, s)
+		if err != nil {
+			t, err = time.Parse(defaultDatabaseGoDateFormat, s)
+			if err != nil {
+				return nil, "", fmt.Errorf("unknown time format %s: expected RFC3339, RFC3339 with nanoseconds or YYYY-MM-DDTHH:MM:SSZ", s)
+			}
+			return &t, DefaultDatabaseDateFormat, nil
+		}
+		return &t, time.RFC3339Nano, nil
+	}
+	return &t, time.RFC3339, nil
+}

--- a/transforms/common.go
+++ b/transforms/common.go
@@ -21,7 +21,7 @@ func parseTime(s string) (*time.Time, string, error) {
 		if err != nil {
 			t, err = time.Parse(defaultDatabaseGoDateFormat, s)
 			if err != nil {
-				return nil, "", fmt.Errorf("unknown time format %s: expected RFC3339, RFC3339 with nanoseconds or YYYY-MM-DDTHH:MM:SSZ", s)
+				return nil, "", fmt.Errorf("unknown time format %s: expected RFC3339, RFC3339 with nanoseconds or %s", s, DefaultDatabaseDateFormat)
 			}
 			return &t, DefaultDatabaseDateFormat, nil
 		}

--- a/transforms/max.go
+++ b/transforms/max.go
@@ -40,6 +40,12 @@ func (s *max) Reduce(arg []interface{}) error {
 		s.result = math.Max(s.result, float64(v))
 	case int32:
 		s.result = math.Max(s.result, float64(v))
+	case string:
+		value, _, err := parseTime(v)
+		if err != nil {
+			return err
+		}
+		s.result = math.Max(s.result, float64(value.Unix()))
 	default:
 		return fmt.Errorf("max takes a single numerical argument, but %v was provided", args[0])
 	}

--- a/transforms/max_test.go
+++ b/transforms/max_test.go
@@ -1,8 +1,9 @@
 package transforms
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestMax(t *testing.T) {
@@ -12,7 +13,7 @@ func TestMax(t *testing.T) {
 		Convey("It should reduce to nil if there are no messages", func() {
 			So(agg.Return(), ShouldBeNil)
 		})
-		Convey("It should reduce multiple message correctly", func() {
+		Convey("It should reduce multiple messages correctly", func() {
 			msgs := [][]interface{}{
 				[]interface{}{0.0},
 				[]interface{}{1},
@@ -25,6 +26,34 @@ func TestMax(t *testing.T) {
 			f := agg.Return()
 			So(f, ShouldNotBeNil)
 			So(*f, ShouldEqual, 1.0)
+		})
+		Convey("It should reduce multiple timestamps correctly", func() {
+			expectedMax := "2018-02-14T11:00:00Z"
+			msgs := [][]interface{}{
+				[]interface{}{"2018-02-14T10:00:00Z"},
+				[]interface{}{"2018-02-14T05:00:00Z"},
+				[]interface{}{"2018-02-14T03:00:00Z"},
+				[]interface{}{"2018-02-14T05:30:00Z"},
+				[]interface{}{expectedMax},
+				[]interface{}{"2018-02-14T05:00:30Z"},
+			}
+			for _, msg := range msgs {
+				err := agg.Reduce(msg)
+				So(err, ShouldBeNil)
+			}
+			f := agg.Return()
+			So(f, ShouldNotBeNil)
+			expectedMaxTimestamp, _, err := parseTime(expectedMax)
+			So(err, ShouldBeNil)
+			So(*f, ShouldEqual, float64(expectedMaxTimestamp.Unix()))
+		})
+		Convey("It should raise an error when a string is not in the expected timestamp formats", func() {
+			expectedRejectionTimestampFormat := "FOO_BAR_BAZ"
+			err := agg.Reduce([]interface{}{expectedRejectionTimestampFormat})
+			So(err, ShouldBeError)
+			So(err.Error(), ShouldEqual, "unknown time format FOO_BAR_BAZ: expected RFC3339, RFC3339 with nanoseconds or YYYY-MM-DDTHH:MM:SSZ")
+			f := agg.Return()
+			So(*f, ShouldBeZeroValue)
 		})
 	})
 }

--- a/transforms/min.go
+++ b/transforms/min.go
@@ -37,6 +37,12 @@ func (s *min) Reduce(arg []interface{}) error {
 		s.result = math.Min(s.result, float64(v))
 	case int32:
 		s.result = math.Min(s.result, float64(v))
+	case string:
+		value, _, err := parseTime(v)
+		if err != nil {
+			return err
+		}
+		s.result = math.Min(s.result, float64(value.Unix()))
 	default:
 		return fmt.Errorf("MIN takes a single numerical argument, but %v was provided", args[0])
 	}

--- a/transforms/min_test.go
+++ b/transforms/min_test.go
@@ -1,8 +1,10 @@
 package transforms
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
+	"math"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestMin(t *testing.T) {
@@ -25,6 +27,40 @@ func TestMin(t *testing.T) {
 			f := agg.Return()
 			So(f, ShouldNotBeNil)
 			So(*f, ShouldEqual, -0.1)
+		})
+		Convey("It should reduce multiple timestamps correctly", func() {
+			expectedMin := "2018-02-13T01:00:00Z"
+			msgs := [][]interface{}{
+				[]interface{}{"2018-02-14T10:00:00Z"},
+				[]interface{}{"2018-02-14T05:00:00Z"},
+				[]interface{}{expectedMin},
+				[]interface{}{"2018-02-14T03:00:00Z"},
+				[]interface{}{"2018-02-14T05:30:00Z"},
+				[]interface{}{"2018-02-14T05:00:30Z"},
+			}
+
+			// the following makes sure the defaults are as expected,
+			// this is waiting for a deeper fix to be performed in the
+			// default values for the "min" structure
+			agg.result = math.MaxFloat64
+
+			for _, msg := range msgs {
+				err := agg.Reduce(msg)
+				So(err, ShouldBeNil)
+			}
+			f := agg.Return()
+			So(f, ShouldNotBeNil)
+			expectedMinTimestamp, _, err := parseTime(expectedMin)
+			So(err, ShouldBeNil)
+			So(*f, ShouldEqual, float64(expectedMinTimestamp.Unix()))
+		})
+		Convey("It should raise an error when a string is not in the expected timestamp formats", func() {
+			expectedRejectionTimestampFormat := "FOO_BAR_BAZ"
+			err := agg.Reduce([]interface{}{expectedRejectionTimestampFormat})
+			So(err, ShouldBeError)
+			So(err.Error(), ShouldEqual, "unknown time format FOO_BAR_BAZ: expected RFC3339, RFC3339 with nanoseconds or YYYY-MM-DDTHH:MM:SSZ")
+			f := agg.Return()
+			So(*f, ShouldBeZeroValue)
 		})
 	})
 }

--- a/transforms/zoh.go
+++ b/transforms/zoh.go
@@ -23,22 +23,6 @@ func (s *zoh) SetArgumentMap(am ArgumentMap) {
 	s.am = am
 }
 
-func parseTime(s string) (*time.Time, string, error) {
-	var (
-		t   time.Time
-		err error
-	)
-	t, err = time.Parse(time.RFC3339, s)
-	if err != nil {
-		t, err = time.Parse(time.RFC3339Nano, s)
-		if err != nil {
-			return nil, "", fmt.Errorf("unknown time format %s: expected RFC3339 or RFC3339 with nanoseconds", s)
-		}
-		return &t, time.RFC3339Nano, nil
-	}
-	return &t, time.RFC3339, nil
-}
-
 func (s *zoh) Reduce(arg []interface{}) error {
 	args := s.am(arg)
 	if len(args) != 4 {


### PR DESCRIPTION
For the `MAX` aggregate transformation, the expected time formats are:

- RFC 3339 (with/without nanoseconds)
- `YYYY-MM-DDTHH:MM:SSZ` (found on data coming in/out of databases)

This could be extended to the aggregate transformations for ~~`MIN`~~ and `AVG` (when downsampling).